### PR TITLE
REVNO is a sha in Git, so need to do a string comparison instead of nume...

### DIFF
--- a/grocery_delivery
+++ b/grocery_delivery
@@ -109,7 +109,7 @@ function update_cookbooks_and_roles() {
   else
     REVNO=$(cat "$REV_CHECKPOINT_FULLPATH")
   fi
-  if [ "$REVNO" -eq 0 ]; then
+  if [ "$REVNO" = "0" ]; then
     # 'knife cookbook upload -a' uploads all your cookbooks.
     ADDED_COOKBOOK_LIST="-a"
     ADDED_ROLE_LIST=$(cd ${ROLES_FULLPATH} && find . -maxdepth 1 -type f | \


### PR DESCRIPTION
Minor change when checking REVNO - git uses a SHA so numeric comparisons throw an error.  Updated to do a string comparison instead.  This change has been tested and is running in production at my company (Ooyala) already.
