### PR TITLE
Fix user for pgsql checks

### DIFF
--- a/chef-server-stats/chef-server-stats
+++ b/chef-server-stats/chef-server-stats
@@ -157,7 +157,7 @@ def get_postgresql_stats(embedded_path)
     stats = {}
     q = "SELECT SUM(#{columns.join('), SUM(')}) FROM pg_stat_all_tables;"
     cmd = "su opscode-pgsql -c \"cd; #{psql_bin} -A -P tuples_only -U " +
-          "opscode_chef_ro -d opscode_chef -c '#{q}'\""
+          "opscode-pgsql -d opscode_chef -c '#{q}'\""
 
     s = Mixlib::ShellOut.new(cmd).run_command
     if s.exitstatus == 0
@@ -169,7 +169,7 @@ def get_postgresql_stats(embedded_path)
     # postgresql connection count
     q = "SELECT count(*) FROM pg_stat_activity WHERE datname = 'opscode_chef';"
     cmd = "su opscode-pgsql -c \"cd; #{psql_bin} -A -P tuples_only -U " +
-          "opscode_chef_ro -d opscode_chef -c \\\"#{q}\\\"\""
+          "opscode-pgsql -d opscode_chef -c \\\"#{q}\\\"\""
 
     s = Mixlib::ShellOut.new(cmd).run_command
     if s.exitstatus == 0


### PR DESCRIPTION
This is the user meant for automation and the only one allowed to connect
without a password in 11.1.8.
