### PR TITLE
fix typo arround in constant name, so that logging succeeds

### DIFF
--- a/grocery-delivery/grocery-delivery.rb
+++ b/grocery-delivery/grocery-delivery.rb
@@ -205,7 +205,7 @@ if repo.exists?
   repo.update unless GroceryDelivery::Config.dry_run
 else
   unless GroceryDelivery::Config.repo_url
-    GroceryDeliver::Log.error(
+    GroceryDelivery::Log.error(
       'No repo URL was specified, and no repo is checked out'
     )
     exit(1)


### PR DESCRIPTION
Fixes issue #35.  Just adding a missing character so logging succeeds.
