### PR TITLE
Fix git initialization with GD

### DIFF
--- a/between-meals/repo/git.rb
+++ b/between-meals/repo/git.rb
@@ -9,7 +9,11 @@ module BetweenMeals
     # Git provider
     class Git < BetweenMeals::Repo
       def setup
-        @repo = Rugged::Repository.new(File.expand_path(@repo_path))
+        if File.exists?(File.expand_path(@repo_path))
+          @repo = Rugged::Repository.new(File.expand_path(@repo_path))
+        else
+          @repo = nil 
+        end
         @bin = 'git'
       end
 
@@ -43,8 +47,11 @@ module BetweenMeals
       end
 
       def checkout(url)
-        s = Mixlib::ShellOut.new("#{@bin} clone #{url} #{@repo}").run_command
+        s = Mixlib::ShellOut.new(
+          "#{@bin} clone #{url} #{@repo} #{@repo_path}"
+        ).run_command
         s.error!
+        @repo = Rugged::Repository.new(File.expand_path(@repo_path))
       end
 
       # libgit turns out to be *very* slow at this. Using /usr/bin/git

--- a/grocery-delivery/grocery-delivery/hooks.rb
+++ b/grocery-delivery/grocery-delivery/hooks.rb
@@ -28,7 +28,7 @@ module GroceryDelivery
     end
 
     def self.get(file)
-      class_eval(File.read(file), __FILE__, __LINE__)
+      class_eval(File.read(file), __FILE__, __LINE__) if File.exists?(file)
     end
   end
 end


### PR DESCRIPTION
This fixes git repo initialization from GD.
It also is a minor GD fix to not crash on no-existent plugins.
