### PR TITLE
use a more sensible value in example code

### DIFF
--- a/cookbooks/fb_sysctl/README.md
+++ b/cookbooks/fb_sysctl/README.md
@@ -16,9 +16,10 @@ Anywhere, in any cookbook, you can set a sysctl in a recipe as follows:
 
     node.default['fb']['fb_sysctl'][$SYSCTL] = $VALUE
 
-For example:
+For example, vm.swappiness can be set to 1 to tell the kernel to only
+application data if it is necessary.
 
-    node.default['fb']['fb_sysctl']['vm.swappiness'] = 70
+    node.default['fb']['fb_sysctl']['vm.swappiness'] = 1
 
 License
 -------


### PR DESCRIPTION
Setting vm.swappiness=70 on a server by copying it from the README
could provide surprising results. The default in the kernel is 60.

A value of 70 instructs the kernel to be more aggressive about
swapping out application data. At a minimum, this will cause needless
IO. In the worst case can render a previously slow system totally
unresponsive.

As the new text in the README says, setting it to 1 is often what
server operators want: the kernel should not swap unless it really
has to.
