### PR TITLE
Add folsom-stats

### DIFF
--- a/chef-server-stats/chef-server-stats
+++ b/chef-server-stats/chef-server-stats
@@ -30,14 +30,13 @@
 if File.exists?('/opt/chef-server/bin/chef-server-ctl')
   embedded_path = '/opt/chef-server/embedded/bin'
   ctl_bin = '/opt/chef-server/bin/chef-server-ctl'
-elsif File.exists?('/opt/opscode/bin/private-chef-ctl')
-  embedded_path = '/opt/opscode/embedded/bin'
-  ctl_bin = '/opt/opscode/bin/private-chef-ctl'
 elsif File.exists?('/opt/opscode/bin/chef-server-ctl')
   chef_server_12 = true
   embedded_path = '/opt/opscode/embedded/bin'
   ctl_bin = '/opt/opscode/bin/chef-server-ctl'
-
+elsif File.exists?('/opt/opscode/bin/private-chef-ctl')
+  embedded_path = '/opt/opscode/embedded/bin'
+  ctl_bin = '/opt/opscode/bin/private-chef-ctl'
 else
   warn 'ERROR: Failed to determine chef server type, exiting'
   warn '       (open-source or privatechef)'
@@ -251,12 +250,16 @@ def get_server_status
   return status
 end
 
-def get_folsom_metrics
+def get_folsom_metrics(chef_server_12)
   result = {}
   if chef_server_12
-    s = Mixlib::ShellOut.new('./folsom-stats')
-    obj = Yajl::Parser.new.parse(s.run_command.stdout)
-    obj.each{|val| result.merge! val }
+    _safe_get(__method__) do
+      if File.exists? "./folsom-stats"
+        s = Mixlib::ShellOut.new('./folsom-stats')
+        obj = Yajl::Parser.new.parse(s.run_command.stdout)
+        obj.each{|val| result.merge! val }
+      end
+    end
   end
   result
 end
@@ -270,7 +273,7 @@ output.merge!(get_postgresql_stats(embedded_path))
 output.merge!(get_authz_stats(services))
 output.merge!(get_redis_stats(services))
 output.merge!(get_server_status)
-output.merge!(get_folsom_metrics)
+output.merge!(get_folsom_metrics(chef_server_12))
 
 # Generate output, pretty if necessary
 if %w{info debug}.include?(Chef::Config[:log_level].to_s)

--- a/chef-server-stats/chef-server-stats
+++ b/chef-server-stats/chef-server-stats
@@ -33,6 +33,11 @@ if File.exists?('/opt/chef-server/bin/chef-server-ctl')
 elsif File.exists?('/opt/opscode/bin/private-chef-ctl')
   embedded_path = '/opt/opscode/embedded/bin'
   ctl_bin = '/opt/opscode/bin/private-chef-ctl'
+elsif File.exists?('/opt/opscode/bin/chef-server-ctl')
+  chef_server_12 = true
+  embedded_path = '/opt/opscode/embedded/bin'
+  ctl_bin = '/opt/opscode/bin/chef-server-ctl'
+
 else
   warn 'ERROR: Failed to determine chef server type, exiting'
   warn '       (open-source or privatechef)'
@@ -246,6 +251,16 @@ def get_server_status
   return status
 end
 
+def get_folsom_metrics
+  result = {}
+  if chef_server_12
+    s = Mixlib::ShellOut.new('./folsom-stats')
+    obj = Yajl::Parser.new.parse(s.run_command.stdout)
+    obj.each{|val| result.merge! val }
+  end
+  result
+end
+
 # Get all the stats!
 output = {}
 output.merge!(get_api_counts(services))
@@ -255,6 +270,7 @@ output.merge!(get_postgresql_stats(embedded_path))
 output.merge!(get_authz_stats(services))
 output.merge!(get_redis_stats(services))
 output.merge!(get_server_status)
+output.merge!(get_folsom_metrics)
 
 # Generate output, pretty if necessary
 if %w{info debug}.include?(Chef::Config[:log_level].to_s)

--- a/chef-server-stats/folsom-stats
+++ b/chef-server-stats/folsom-stats
@@ -1,0 +1,40 @@
+#!/usr/bin/env escript
+
+-define(ERCHEF, 'erchef@127.0.0.1').
+-define(ERCHEF_COOKIE, 'erchef').
+-define(SELF, 'chef-stats@127.0.0.1').
+
+fetch_metric({MetricKey, [MetricType = {type, histogram} ]}) ->
+    {MetricKey, rpc:call(?ERCHEF, folsom_metrics,get_histogram_statistics, [MetricKey]), MetricType};
+fetch_metric({MetricKey, [MetricType]}) ->
+    {MetricKey, rpc:call(?ERCHEF, folsom_metrics,get_metric_value,[MetricKey]), MetricType}.
+
+normalize_data([{_,_} | _] = Vals) ->
+    {lists:foldl(fun({Val1, Val2}, AccIn) -> [{normalize_data(Val1), normalize_data(Val2)} | AccIn] end, [], Vals)};
+normalize_data(Val) ->
+    [Result] = io_lib:format("~p", [Val]),
+    list_to_binary(Result).
+
+process_metric({MetricKey, MetricData, MetricType}) ->
+    NormalizedData = normalize_data([MetricType | MetricData]),
+    {[{MetricKey, NormalizedData}]}.
+
+process_metrics(AccIn, []) ->
+    lists:reverse(AccIn);
+process_metrics(AccIn, [Metric | Metrics]) ->
+    MetricData = fetch_metric(Metric),
+    process_metrics([ process_metric(MetricData) | AccIn], Metrics).
+
+process_metrics(Metrics) ->
+    process_metrics([], Metrics).
+
+init_network() ->
+    net_kernel:start([?SELF, longnames]),
+    erlang:set_cookie(node(), ?ERCHEF_COOKIE),
+    pong = net_adm:ping(?ERCHEF).
+
+main(_Args) ->
+    init_network(),
+    MetricsInfo = rpc:call(?ERCHEF, folsom_metrics, get_metrics_info, []),
+    ProcessedMetrics = process_metrics(MetricsInfo),
+    io:format("~s~n", [rpc:call(?ERCHEF, jiffy, encode, [ProcessedMetrics])]).


### PR DESCRIPTION
folsom-stats will remote into a running erchef instance and gather the folsom
metrics, dumping them to a json array. Only runs with chef-server 12.