### PR TITLE
Make chef-server-stats work with Chef 12

### DIFF
--- a/chef-server-stats/chef-server-stats
+++ b/chef-server-stats/chef-server-stats
@@ -9,15 +9,14 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 
 # Returns a json object of key/value pairs suitable for time-series graphing.
 # Run with -V for pretty-printed JSON. We assume this is running on the chef
@@ -41,7 +40,7 @@ else
 end
 
 # Get the list of services so we can skip irrelevant ones (like on a chef
-# server frontend in the tiered model). 
+# server frontend in the tiered model).
 cmd = "#{ctl_bin} service-list"
 s = Mixlib::ShellOut.new(cmd).run_command
 if s.exitstatus == 0
@@ -51,7 +50,7 @@ else
   exit 1
 end
 # Remove extraneous *, we'll test any listed service just to be sure.
-services.map! {|service| service.chomp('*')}
+services.map! { |service| service.chomp('*') }
 
 # Convenience method to do the thing that should return a hash. If it explodes
 # for any reason just return an empty hash anyway so we can move on. We do this
@@ -59,15 +58,13 @@ services.map! {|service| service.chomp('*')}
 # architecture or OSC which could have services split in various ways. We just
 # try every stat and report anything we're able to collect.
 def _safe_get(name)
-  begin
-    yield
-  rescue Exception => e
-    if %w{info debug}.include?(Chef::Config[:log_level].to_s)
-      warn "#{name}: #{e.message}"
-      warn e.backtrace.inspect if Chef::Config[:log_level].to_s == 'debug'
-    end
-    return {}
+  yield
+rescue => e
+  if %w{info debug}.include?(Chef::Config[:log_level].to_s)
+    warn "#{name}: #{e.message}"
+    warn e.backtrace.inspect if Chef::Config[:log_level].to_s == 'debug'
   end
+  return {}
 end
 
 # Get counts from the chef server API
@@ -79,7 +76,7 @@ def get_api_counts(services)
     Chef::Config[:http_retry_count] = 0
     stats = {
       # Skip client count because searching is slow. Uncomment if you like.
-      #'chef.server.num_clients' => search(:client, "*:*").count,
+      # 'chef.server.num_clients' => search(:client, "*:*").count,
       'chef.server.num_nodes' => api.get('nodes').count,
       'chef.server.num_cookbooks' => api.get('cookbooks').count,
       'chef.server.num_roles' => api.get('roles').count,
@@ -93,8 +90,7 @@ def get_couchdb_stats(services)
   return {} unless services.include?('couchdb')
   _safe_get(__method__) do
     stat_res = Net::HTTP.get_response('localhost', '/_stats', '5984').body
-    parser = Yajl::Parser.new
-    couch_stats = parser.parse(stat_res)
+    couch_stats = Chef::JSONCompat.from_json(stat_res)
 
     # Couch stats can return null if there's no data so convert to 0 if needed
     stats = {
@@ -186,8 +182,7 @@ def get_authz_stats(services)
   # Grabs :9683/_ping from a chef server and pulls out interesting authz stats
   _safe_get(__method__) do
     stat_res = Net::HTTP.get_response('localhost', '/_ping', '9683').body
-    parser = Yajl::Parser.new
-    authz_stats = parser.parse(stat_res)
+    authz_stats = Chef::JSONCompat.from_json(stat_res)
     stats = {}
 
     authz_stats['system_statistics'].each_key do |k|
@@ -229,14 +224,13 @@ end
 # Check server status
 def get_server_status
   status = _safe_get(__method__) do
-    uri = URI.parse("https://localhost/_status")
+    uri = URI.parse('https://localhost/_status')
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = true
     http.verify_mode = OpenSSL::SSL::VERIFY_NONE
     request = Net::HTTP::Get.new(uri.request_uri)
     response = http.request(request)
-    parser = Yajl::Parser.new
-    status_hash = parser.parse(response.body)
+    status_hash = Chef::JSONCompat.from_json(response.body)
     if status_hash['status'] == 'pong'
       server_status = { 'chef.server.status' => 1 }
     else
@@ -251,7 +245,6 @@ def get_server_status
   end
   return status
 end
-
 
 # Get all the stats!
 output = {}


### PR DESCRIPTION
- YAJL doesn't exist in chef-client 12 anymore
- some other lint stuff
