### PR TITLE
Make fb_sysctl work under chef12

### DIFF
--- a/cookbooks/fb_sysctl/libraries/sync.rb
+++ b/cookbooks/fb_sysctl/libraries/sync.rb
@@ -17,7 +17,7 @@
 
 module FB
   module FBSysctl
-    def sysctl_in_sync?
+    def self.sysctl_in_sync?(node)
       # Get current settings
       s = Mixlib::ShellOut.new('/sbin/sysctl -a')
       s.run_command

--- a/cookbooks/fb_sysctl/recipes/default.rb
+++ b/cookbooks/fb_sysctl/recipes/default.rb
@@ -17,8 +17,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-Chef::Resource::Execute.send(:include, FB::FBSysctl)
-
 whyrun_safe_ruby_block 'sysctl sanity checks' do
   block do
     node['fb']['fb_sysctl'].to_hash.each do |sysctl, _val|
@@ -59,6 +57,6 @@ end
 
 # Safety check in case we missed a notification above
 execute 'reread-sysctl' do
-  not_if { sysctl_in_sync? }
+  not_if { FB::FBSysctl.sysctl_in_sync?(node) }
   command '/sbin/sysctl -p'
 end

--- a/cookbooks/fb_sysctl/recipes/default.rb
+++ b/cookbooks/fb_sysctl/recipes/default.rb
@@ -17,6 +17,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+Chef::Resource::Execute.send(:include, FB::FBSysctl)
+
 whyrun_safe_ruby_block 'sysctl sanity checks' do
   block do
     node['fb']['fb_sysctl'].to_hash.each do |sysctl, _val|
@@ -57,6 +59,6 @@ end
 
 # Safety check in case we missed a notification above
 execute 'reread-sysctl' do
-  not_if { FB::FBSysctl.sysctl_in_sync? }
+  not_if { sysctl_in_sync? }
   command '/sbin/sysctl -p'
 end


### PR DESCRIPTION
Without that FB::FBSysctl.sysctl_in_sync? was not found. Pretty much #dogsciencing this