### PR TITLE
Support Amazon Linux's AMI

### DIFF
--- a/cookbooks/fb_cron/recipes/default.rb
+++ b/cookbooks/fb_cron/recipes/default.rb
@@ -26,7 +26,10 @@ when 'debian'
 when 'mac_os_x'
   svc_name = 'com.vix.cron'
 when 'rhel'
-  package_name = node['platform_version'] >= 6 ? 'cronie' : 'vixie-cron'
+  package_name = 'vixie-cron'
+  if node['platform'] == 'amazon' || node['platform_version'] >= 6
+    package_name = 'cronie'
+  end
   svc_name = 'crond'
 when 'fedora', 'suse'
   package_name 'cronie'


### PR DESCRIPTION
Amazon AMI report rhel platform family, but their numbering goes YYYY.MM
(e.g 2015.03).
While this may not handle old AMI versions, it is going to provide a
best guess.