### PR TITLE
Add CS12 support for folsom-stats

### DIFF
--- a/chef-server-stats/chef-server-stats
+++ b/chef-server-stats/chef-server-stats
@@ -28,8 +28,6 @@
 
 # Determine if we're running open source Chef server or private chef
 
-require 'yajl'
-
 if File.exists?('/opt/chef-server/bin/chef-server-ctl')
   embedded_path = '/opt/chef-server/embedded/bin'
   ctl_bin = '/opt/chef-server/bin/chef-server-ctl'
@@ -259,7 +257,7 @@ def get_folsom_metrics(chef_server_12)
     _safe_get(__method__) do
       if File.exists? "./folsom-stats"
         s = Mixlib::ShellOut.new('./folsom-stats')
-        obj = Yajl::Parser.new.parse(s.run_command.stdout)
+        obj = Chef::JSONCompat.from_json(s.run_command.stdout)
         obj.each{|val| result.merge! val }
       end
     end

--- a/chef-server-stats/chef-server-stats
+++ b/chef-server-stats/chef-server-stats
@@ -27,6 +27,9 @@
 # Usage: knife exec chef-server-stats [-V]
 
 # Determine if we're running open source Chef server or private chef
+
+require 'yajl'
+
 if File.exists?('/opt/chef-server/bin/chef-server-ctl')
   embedded_path = '/opt/chef-server/embedded/bin'
   ctl_bin = '/opt/chef-server/bin/chef-server-ctl'

--- a/chef-server-stats/folsom-stats
+++ b/chef-server-stats/folsom-stats
@@ -6,8 +6,12 @@
 
 fetch_metric({MetricKey, [MetricType = {type, histogram} ]}) ->
     {MetricKey, rpc:call(?ERCHEF, folsom_metrics,get_histogram_statistics, [MetricKey]), MetricType};
+fetch_metric({MetricKey, [MetricType = {type, histogram}, _]}) ->
+    {MetricKey, rpc:call(?ERCHEF, folsom_metrics,get_histogram_statistics, [MetricKey]), MetricType};
 fetch_metric({MetricKey, [MetricType]}) ->
-    {MetricKey, rpc:call(?ERCHEF, folsom_metrics,get_metric_value,[MetricKey]), MetricType}.
+    {MetricKey, rpc:call(?ERCHEF, folsom_metrics,get_metric_value,[MetricKey]), MetricType};
+fetch_metric({MetricKey, [MetricType, _]}) ->
+    {MetricKey, rpc:call(?ERCHEF, folsom_metrics,get_metric_value, [MetricKey]), MetricType}.
 
 normalize_data([{_,_} | _] = Vals) ->
     {lists:foldl(fun({Val1, Val2}, AccIn) -> [{normalize_data(Val1), normalize_data(Val2)} | AccIn] end, [], Vals)};


### PR DESCRIPTION
Adding CS12 support for folsom-stats.

We have to add an extra function clause for newer versions of chef-server, to handle extraneous data sent from folsom compared to previous versions.