### PR TITLE
Add support for histograms in chef-server v12.1 and newer

### DIFF
--- a/chef-server-stats/chef-server-stats
+++ b/chef-server-stats/chef-server-stats
@@ -267,6 +267,8 @@ def get_folsom_metrics(chef_server_12)
             value = nil
             if data['type'] == 'histogram'
               result["chef.server.#{svc}"] = data['arithmetic_mean']
+              result["chef.server.#{svc}.min"] = data['min']
+              result["chef.server.#{svc}.max"] = data['max']
               next
             elsif data['type'] == 'meter'
               result["chef.server.#{svc}"] = data['count']

--- a/chef-server-stats/chef-server-stats
+++ b/chef-server-stats/chef-server-stats
@@ -265,12 +265,8 @@ def get_folsom_metrics(chef_server_12)
         obj.each do |blob|
           blob.each do |svc, data|
             value = nil
-            if data['type'] == 'histogram'
-              # we skip this for now.
-            elsif data['type'] == 'meter'
-              result["chef.server.#{svc}"] = data['count']
-              next
-            end
+            result["chef.server.#{svc}"] = data['count']
+            next
           end
         end
       end

--- a/chef-server-stats/chef-server-stats
+++ b/chef-server-stats/chef-server-stats
@@ -271,6 +271,9 @@ def get_folsom_metrics(chef_server_12)
             elsif data['type'] == 'meter'
               result["chef.server.#{svc}"] = data['count']
               next
+            elsif data['type'] == 'counter'
+              result["chef.server.#{svc}"] = data['current']
+              next
             end
           end
         end

--- a/chef-server-stats/chef-server-stats
+++ b/chef-server-stats/chef-server-stats
@@ -265,8 +265,13 @@ def get_folsom_metrics(chef_server_12)
         obj.each do |blob|
           blob.each do |svc, data|
             value = nil
-            result["chef.server.#{svc}"] = data['count']
-            next
+            if data['type'] == 'histogram'
+              result["chef.server.#{svc}"] = data['current']
+              next
+            elsif data['type'] == 'meter'
+              result["chef.server.#{svc}"] = data['count']
+              next
+            end
           end
         end
       end

--- a/chef-server-stats/chef-server-stats
+++ b/chef-server-stats/chef-server-stats
@@ -266,7 +266,7 @@ def get_folsom_metrics(chef_server_12)
           blob.each do |svc, data|
             value = nil
             if data['type'] == 'histogram'
-              result["chef.server.#{svc}"] = data['current']
+              result["chef.server.#{svc}"] = data['arithmetic_mean']
               next
             elsif data['type'] == 'meter'
               result["chef.server.#{svc}"] = data['count']

--- a/chef-server-stats/chef-server-stats
+++ b/chef-server-stats/chef-server-stats
@@ -266,7 +266,7 @@ def get_folsom_metrics(chef_server_12)
           blob.each do |svc, data|
             value = nil
             if data['type'] == 'histogram'
-              result["chef.server.#{svc}"] = data['arithmetic_mean']
+              result["chef.server.#{svc}.mean"] = data['arithmetic_mean']
               result["chef.server.#{svc}.min"] = data['min']
               result["chef.server.#{svc}.max"] = data['max']
               next

--- a/chef-server-stats/folsom-stats
+++ b/chef-server-stats/folsom-stats
@@ -7,7 +7,7 @@
 fetch_metric({MetricKey, [MetricType = {type, histogram} ]}) ->
     {MetricKey, rpc:call(?ERCHEF, folsom_metrics,get_histogram_statistics, [MetricKey]), MetricType};
 fetch_metric({MetricKey, [MetricType = {type, histogram}, _]}) ->
-      {MetricKey, rpc:call(?ERCHEF, folsom_metrics,get_metric_value, [MetricKey]), MetricType};
+    {MetricKey, rpc:call(?ERCHEF, folsom_metrics,get_metric_value, [MetricKey]), MetricType};
 fetch_metric({MetricKey, [MetricType]}) ->
     {MetricKey, rpc:call(?ERCHEF, folsom_metrics,get_metric_value,[MetricKey]), MetricType};
 fetch_metric({MetricKey, [MetricType, _]}) ->

--- a/chef-server-stats/folsom-stats
+++ b/chef-server-stats/folsom-stats
@@ -13,9 +13,9 @@ fetch_metric({MetricKey, [MetricType]}) ->
 fetch_metric({MetricKey, [MetricType, _]}) ->
     {MetricKey, rpc:call(?ERCHEF, folsom_metrics,get_metric_value, [MetricKey]), MetricType}.
 
-normalize_data([{type,counter}, _]) ->
-%%No support for counters yet
-    {[{<<"current">>,<<"Unsupported">>},{<<"type">>,<<"counter">>}]};
+normalize_data([{type,counter}|CounterData = _]) ->
+    Result = integer_to_binary(CounterData),
+    {[{<<"current">>,Result},{<<"type">>,<<"counter">>}]};
 normalize_data([{_,_} | _] = Vals) ->
     {lists:foldl(fun({Val1, Val2}, AccIn) -> [{normalize_data(Val1), normalize_data(Val2)} | AccIn] end, [], Vals)};
 normalize_data(Val) ->

--- a/chef-server-stats/folsom-stats
+++ b/chef-server-stats/folsom-stats
@@ -7,15 +7,15 @@
 fetch_metric({MetricKey, [MetricType = {type, histogram} ]}) ->
     {MetricKey, rpc:call(?ERCHEF, folsom_metrics,get_histogram_statistics, [MetricKey]), MetricType};
 fetch_metric({MetricKey, [MetricType = {type, histogram}, _]}) ->
-    {MetricKey, rpc:call(?ERCHEF, folsom_metrics,get_metric_value, [MetricKey]), MetricType};
+    {MetricKey, rpc:call(?ERCHEF, folsom_metrics,get_histogram_statistics, [MetricKey]), MetricType};
 fetch_metric({MetricKey, [MetricType]}) ->
     {MetricKey, rpc:call(?ERCHEF, folsom_metrics,get_metric_value,[MetricKey]), MetricType};
 fetch_metric({MetricKey, [MetricType, _]}) ->
     {MetricKey, rpc:call(?ERCHEF, folsom_metrics,get_metric_value, [MetricKey]), MetricType}.
 
-normalize_data([{type,histogram}, HistogramData = _,_ | _]) ->
-    HistoResult = integer_to_binary(HistogramData),
-    {[{<<"current">>,HistoResult},{<<"type">>,<<"histogram">>}]};
+normalize_data([{type,counter}, _]) ->
+%%No support for counters yet
+    {[{<<"current">>,<<"Unsupported">>},{<<"type">>,<<"counter">>}]};
 normalize_data([{_,_} | _] = Vals) ->
     {lists:foldl(fun({Val1, Val2}, AccIn) -> [{normalize_data(Val1), normalize_data(Val2)} | AccIn] end, [], Vals)};
 normalize_data(Val) ->

--- a/chef-server-stats/folsom-stats
+++ b/chef-server-stats/folsom-stats
@@ -14,8 +14,8 @@ fetch_metric({MetricKey, [MetricType, _]}) ->
     {MetricKey, rpc:call(?ERCHEF, folsom_metrics,get_metric_value, [MetricKey]), MetricType}.
 
 normalize_data([{type,histogram}, HistogramData = _,_ | _]) ->
-      HistoResult = integer_to_binary(HistogramData),
-    {[{<<"current">>,HistoResult}]};
+    HistoResult = integer_to_binary(HistogramData),
+    {[{<<"current">>,HistoResult},{<<"type">>,<<"histogram">>}]};
 normalize_data([{_,_} | _] = Vals) ->
     {lists:foldl(fun({Val1, Val2}, AccIn) -> [{normalize_data(Val1), normalize_data(Val2)} | AccIn] end, [], Vals)};
 normalize_data(Val) ->


### PR DESCRIPTION
Added support for counter types in folsom-stats.

Added code for chef-server-stats to collect min, max and mean from histograms and 'current' from counters.

As it stands today there isn't a great way to get the 'current' metric value out of the histograms we build with chef-server. By using a combo of min, max and mean we should be able to glean some useful metrics. There's ongoing discussion to change how histograms are handled.