### PR TITLE
Remove rabbitmq management http pool from enumerated pools

### DIFF
--- a/chef-server-stats/real-time-pool-stats
+++ b/chef-server-stats/real-time-pool-stats
@@ -6,7 +6,7 @@
 -define(A2B(X), erlang:atom_to_binary(X, utf8)).
 
 check_metrics() ->
-    Pools = [sqerl, oc_chef_authz_http, chef_index_http, chef_depsolver, rabbitmq_management_service],
+    Pools = [sqerl, oc_chef_authz_http, chef_index_http, chef_depsolver],
     Metrics = get_metrics(Pools),
     rpc:call(?ERCHEF,chef_json,encode,[{[{<<"pooler_metrics">>,{Metrics}}]}]).
 


### PR DESCRIPTION
This pool doesn't provide meaningful monitoring data, and only exists in newer Chef server versions, causing the pooler metrics script to break for Chef server versions 12.2 and 12.5.