### PR TITLE
Fix stdout logging from chefctl

### DIFF
--- a/chefctl/src/chefctl.rb
+++ b/chefctl/src/chefctl.rb
@@ -79,6 +79,8 @@ module Chefctl
     end
     @logger.loggers.each do |log|
       log.formatter = proc do |severity, datetime, progname, msg|
+        progname ||= program_name
+        msg = msg[:msg] if msg.is_a?(Hash)
         "[#{datetime}] #{severity} #{progname}: #{msg}\n"
       end
       log.progname = program_name


### PR DESCRIPTION
This PR fixes two issues:

1. Chefctl assumes the logger from `Mixlib::Log::Logger` and `Logger` are
the same, but they are not. One's message is a has and ones is a string.
2. Mixlib::Log doesn't know about programname in the way Logger does,
so console messages were also missing that and had an awkward space.
This fills in a sane default.

With this PR messages go from:
```
[2019-07-27 00:01:11 +0000] INFO : {:msg=>"Updating chef repo"}
```
to
```
[2019-07-27 00:01:25 +0000] INFO chefctl: Updating chef repo
```

Signed-off-by: Phil Dibowitz <phil@ipom.com>