### PR TITLE
chefctl: implement `stop_or_wait_for_chef`

### DIFF
--- a/chefctl/src/chefctl.rb
+++ b/chefctl/src/chefctl.rb
@@ -549,6 +549,7 @@ module Chefctl
             # Don't kill any ssh processes, but we might kill their children
             # separately. It'll get cleaned up if the child gets killed anyway.
             /ssh/,
+            # Facebook-ism, ignore
             /sush/,
           ],
         )
@@ -1236,6 +1237,13 @@ if $PROGRAM_NAME == __FILE__
     end
 
     parser.on(
+      '-w', '--wait-for-chef',
+      'Simply run the stop-or-wait-for-chef step, do not actually run Chef'
+    ) do
+      options[:wait_for_chef] = true
+    end
+
+    parser.on(
       '--program PROGRAM',
       "name of the chefctl process. defaults to '#{$PROGRAM_NAME}'",
     ) do |v|
@@ -1264,6 +1272,11 @@ if $PROGRAM_NAME == __FILE__
   FileUtils.touch(logfile)
   Chefctl.init_logger(logfile)
   Chefctl.logger.level = :debug if Chefctl::Config.verbose
+
+  if options[:wait_for_chef]
+    Chefctl.lib.stop_or_wait_for_chef
+    exit
+  end
 
   Chefctl::Plugin.get_plugin.pre_start
 


### PR DESCRIPTION
Facebook, and presumably others, have scripts that do things like:

```
CHEFCTL_PATH = '/path/to/chefctl.rb'

require_relative CHEFCTL_PATH
Chefctl.lib.load_config(Chefctl::DEFAULT_CONFIG)
Chefctl.lib.check_user
Chefctl.lib.stop_or_wait_for_chef
```

Which of course is fragile and a bit hacky. Instead, lets just provide
an option `-w` to chefctl that does this.