### PR TITLE
[rubocop] use main branch for download

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 Gemfile.lock
-.rubocop-https---raw-githubusercontent-com-facebook-chef-cookbooks-master--rubocop-yml
+.rubocop-https*

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 inherit_from:
-    - https://raw.githubusercontent.com/facebook/chef-cookbooks/master/.rubocop.yml
+    - https://raw.githubusercontent.com/facebook/chef-cookbooks/main/.rubocop.yml
 
 # TODO: This will require some testing before enabling
 Style/GlobalStdStream:


### PR DESCRIPTION
Make gitignore less specific for rubocop local configs as well