### PR TITLE
chefctl: fix a hard-coded path

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,3 @@
 source 'https://rubygems.org'
+gem 'base64'
 gem 'rubocop', '= 1.25.1'

--- a/chefctl/src/chefctl.rb
+++ b/chefctl/src/chefctl.rb
@@ -170,6 +170,9 @@ module Chefctl
     # See Chefctl::Plugin.rerun_chef?
     max_retries 1
 
+    # where to find certs and configs
+    client_config_dir '/etc/chef'
+
     # The testing timestamp.
     # See https://github.com/facebook/taste-tester
     testing_timestamp '/etc/chef/test_timestamp'
@@ -249,7 +252,7 @@ module Chefctl
     # them if necessary.
     # The return value is ignored.
     def generate_certs
-      client_prod_cert = '/etc/chef/client-prod.pem'
+      client_prod_cert = "#{Chefctl::Config.client_config_dir}/client-prod.pem"
       if File.zero?(client_prod_cert)
         Chefctl.logger.info('zero-byte client pem found, removing')
         File.unlink(client_prod_cert)


### PR DESCRIPTION
This adds a configuration for `chef_config_dir` where we can look for
the prod cert link rather than assuming `/etc/chef` - so that those
using cinc can use chefctl more easily.

The default is, of course `/etc/chef` so nothing will change for anyone
not specifying this config.

Also: gem file update is to fix tests - rubocopy fails to run without
base64 installed:

```
/opt/hostedtoolcache/Ruby/3.4.1/x64/lib/ruby/3.4.0/bundled_gems.rb:82:in 'Kernel.require': cannot load such file -- base64 (LoadError)
```

Side note, what I really wanted to do was create a `client_distro`, and
then build the defaults based on _that_, but to allow people to still be
able to overwrite _that_ requires significant refactoring, using the new
`default(..)` syntax for mixlib-config and then creating a method for
most of the configs, and that seemed like too much change for something
so small, so I did not.

Signed-off-by: Phil Dibowitz <phil@ipom.com>
