### PR TITLE
[github CI] Remove Ruby 2.5 + 2.6 testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.5, 2.6, 2.7, 3.0, 3.1]
+        ruby: ["2.7", "3.0", "3.1"]
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository


### PR DESCRIPTION
Also fixes bug where 3.0 gets converted to '3' in YAML and pulls in the latest Ruby (which isn't our intention here)