### PR TITLE
[chefctl] Move default lockfile location

### DIFF
--- a/chefctl/src/chefctl.rb
+++ b/chefctl/src/chefctl.rb
@@ -150,7 +150,7 @@ module Chefctl
     immediate false
 
     # The lock file to use for chefctl.
-    lock_file '/var/lock/subsys/chefctl'
+    lock_file '/var/lock/chefctl.lock'
 
     # How long to wait for the lock to become available.
     lock_time 1800


### PR DESCRIPTION
`/var/lock/subsys` was meant for SysV startup serialization, and was
never the right locationf or our lockfile.

Moreover, recent systemd releases no longer keep the `legacy.conf`
configuration that creates `/var/lock/subsys`, so this means chefctl
no longer works out of the box.

Move the default to something more modern and sane.

*NOTE*: If Meta doesn't explicitly set a `lock_file` setting in their
`chefctl-config.rb`, they should before merging this.

Signed-off-by: Phil Dibowitz <phil@ipom.com>
